### PR TITLE
Add an icon to README.md showing the master build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
+[![Build Status](https://travis-ci.org/stepchowfun/long-distance-interaction.svg?branch=master)](https://travis-ci.org/stepchowfun/long-distance-interaction)
+
 [Here](https://s3.amazonaws.com/stephan-misc/paper/latest.pdf) is a link to the latest PDF.


### PR DESCRIPTION
Add an icon to `README.md` showing the master build status. This is what it looks like:

[![Build Status](https://travis-ci.org/stepchowfun/long-distance-interaction.svg?branch=master)](https://travis-ci.org/stepchowfun/long-distance-interaction)

With this, we don't really need all changes to go through PRs. It will be easy enough to see if someone broke the build just by looking at the readme.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-build-status.pdf) is a link to the PDF generated from this PR.
