### PR TITLE
Introduce user-defined effects (single operation for now) and fix some of the weakening rules

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -30,19 +30,12 @@
 
 % Terms
 \newcommand\eterm{t}
-\newcommand\evalue{v}
 \newcommand\econst{c}
 \newcommand\evar{x}
 \newcommand\eabs[2]{\lambda #1 \; . \; #2} % chktex 1 chktex 26
 \newcommand\eapp[2]{#1 \; #2}
 \newcommand\eappx[2]{#1 \; \$ \; #2}
-\newcommand\eprovide[4]{\text{provide} \; #1 \; \text{as} \; #2 \; \text{using} \; #3 \; \text{in} \; #4}
-
-% Provide
-\newcommand\pall{S}
-\newcommand\pitem[2]{#1 \mapsto #2} % chktex 1
-\newcommand\pempty{\varnothing_{\pall}}
-\newcommand\pextend[2]{#1, #2}
+\newcommand\eeffect[4]{\text{effect} \; #1 \; \text{with} \; \tanno{#2}{#3} \; \text{in} \; #4}
 
 % Types
 \newcommand\ttype{\tau}
@@ -55,16 +48,12 @@
 \newcommand\twithx[2]{#1 \; ! \; #2} % chktex 26
 
 % Effects
-\newcommand\xeffect{\varepsilon}
-\newcommand\xeffects{E}
+\newcommand\xeffect{e}
+\newcommand\xeffects{\Delta}
 \newcommand\xempty{\varnothing_{\xeffect}}
 \newcommand\xextend[2]{#1, #2}
 \newcommand\xunion[2]{#1, #2}
-\newcommand\xdiff[2]{#1 - #2} % chktex 8
-\newcommand\xc{\Delta}
-\newcommand\xcempty{\varnothing_{\xc}}
-\newcommand\xcextend[2]{#1, #2}
-\newcommand\xcitem[2]{#1 = #2}
+\newcommand\xnotint[2]{#1 \notin #2} % chktex 1
 
 % Contexts
 \newcommand\ccontext{\Gamma}
@@ -85,17 +74,12 @@
       \begin{center}
         \begin{tabular}{l l l}
           $\eterm \Coloneqq $ & & term \\
-          & $\evalue$ & value \\
+          & $\econst$ & constant \\
           & $\evar$ & variable \\
+          & $\eabs{\tanno{\evar}{\tx}}{\eterm}$ & abstraction \\
           & $\eapp{\eterm}{\eterm}$ & effect-realizing application \\
           & $\eappx{\eterm}{\eterm}$ & effect-preserving application \\
-          & $\eprovide{\pall}{\xeffect}{\xeffects}{\eterm}$ & provide \\
-          $\evalue \Coloneqq $ & & value \\
-          & $\econst$ & constant \\
-          & $\eabs{\tanno{\evar}{\tx}}{\eterm}$ & abstraction \\
-          $\pall \Coloneqq$ & & effect handler \\
-          & $\pempty$ & empty handler \\
-          & $\pextend{\pall}{\pitem{\evar}{\eterm}}$ & handler extension \\
+          & $\eeffect{\xeffect}{\evar}{\tx}{\eterm}$ & effect introduction \\
           $\ttype \Coloneqq$ & & type \\
           & $\tconst$ & type of constants \\
           & $\tarrow{\tx}{\tx}$ & arrow type \\
@@ -104,9 +88,6 @@
           $\xeffects \Coloneqq$ & & effect set \\
           & $\xempty$ & empty effect \\
           & $\xextend{\xeffects}{\xeffect}$ & effect extension \\
-          $\xc \Coloneqq$ & & effect context \\
-          & $\xcempty$ & empty effect context \\
-          & $\xcextend{\xc}{\xcitem{\xeffect}{\ccontext}}$ & effect introduction \\
           $\ccontext \Coloneqq$ & & type context \\
           & $\cempty$ & empty type context \\
           & $\cextend{\ccontext}{\tanno{\evar}{\tx}}$ & variable binding \\
@@ -115,7 +96,7 @@
 
       \bigskip
 
-      Let $\xunion{\xeffects_1}{\xeffects_2}$ denote the concatenation of $\xeffects_1$ and $\xeffects_2$. Formally, let $\xunion{\xeffects}{\xempty} = \xeffects$ and $\xunion{\xeffects_1}{\parens{\xextend{\xeffects_2}{\xeffect}}} = \xextend{\parens{\xunion{\xeffects_1}{\xeffects_2}}}{\xeffect}$. Similarly, let $\cunion{\ccontext_1}{\ccontext_2}$ denote the concatenation of $\ccontext_1$ and $\ccontext_2$. Formally, let $\cunion{\ccontext}{\cempty} = \ccontext$ and $\cunion{\ccontext_1}{\parens{\cextend{\ccontext_2}{\tanno{\evar}{\tx}}}} = \cextend{\parens{\cunion{\ccontext_1}{\ccontext_2}}}{\tanno{\evar}{\tx}}$.
+      Let $\xunion{\xeffects_1}{\xeffects_2}$ denote the concatenation of $\xeffects_1$ and $\xeffects_2$. Formally, let $\xunion{\xeffects}{\xempty} = \xeffects$ and $\xunion{\xeffects_1}{\parens{\xextend{\xeffects_2}{\xeffect}}} = \xextend{\parens{\xunion{\xeffects_1}{\xeffects_2}}}{\xeffect}$. Similarly, let $\cunion{\ccontext_1}{\ccontext_2}$ denote the concatenation of $\ccontext_1$ and $\ccontext_2$. Formally, let $\cunion{\ccontext}{\cempty} = \ccontext$ and $\cunion{\ccontext_1}{\parens{\cextend{\ccontext_2}{\tanno{\evar}{\tx}}}} = \cextend{\parens{\cunion{\ccontext_1}{\ccontext_2}}}{\tanno{\evar}{\tx}}$. Let $\xnotint{\xeffect}{\tx}$ denote the judgment that $\xeffect$ does not appear anywhere in the type or effects of $\tx$.
 
       \caption{Syntax}\label{fig:syntax}
     \end{mdframed}
@@ -142,35 +123,30 @@
       \end{prooftree}
 
       \begin{prooftree}
-        \AxiomC{$\tjudgment{\cextend{\ccontext}{\tanno{\evar}{\tx_1}}}{\eterm}{\tx_2}$}
+          \AxiomC{$\tjudgment{\cextend{\ccontext}{\tanno{\evar}{\tx_1}}}{\eterm}{\tx_2}$}
         \RightLabel{(\textsc{T-Abstraction})}
         \UnaryInfC{$\tjudgment{\ccontext}{\eabs{\tanno{\evar}{\tx_1}}{\eterm}}{\tarrow{\tx_1}{\tx_2}}$}
       \end{prooftree}
 
       \begin{prooftree}
-        \AxiomC{\Shortstack[c]{{$\tjudgment{\ccontext}{\eterm_1}{\twithx{\xeffects_1}{\ttype_1}}$}
+          \AxiomC{\Shortstack[c]{{$\tjudgment{\ccontext}{\eterm_1}{\twithx{\xeffects_1}{\ttype_1}}$}
           {$\tjudgment{\ccontext}{\eterm_2}{\twithx{\xeffects_3}{\parens{\tarrow{\twithx{\xempty}{\ttype_1}}{\twithx{\xeffects_2}{\ttype_2}}}}}$}}}
         \RightLabel{(\textsc{T-Application1})}
         \UnaryInfC{$\tjudgment{\ccontext}{\eapp{\eterm_2}{\eterm_1}}{\twithx{\xunion{\xeffects_1}{\xunion{\xeffects_2}{\xeffects_3}}}{\ttype_2}}$}
       \end{prooftree}
 
       \begin{prooftree}
-        \AxiomC{\Shortstack[c]{{$\tjudgment{\ccontext}{\eterm_1}{\tx}$}
+          \AxiomC{\Shortstack[c]{{$\tjudgment{\ccontext}{\eterm_1}{\tx}$}
           {$\tjudgment{\ccontext}{\eterm_2}{\twithx{\xeffects_1}{\parens{\tarrow{\tx}{\twithx{\xeffects_2}{\ttype_2}}}}}$}}}
         \RightLabel{(\textsc{T-Application2})}
         \UnaryInfC{$\tjudgment{\ccontext}{\eappx{\eterm_2}{\eterm_1}}{\twithx{\xunion{\xeffects_1}{\xeffects_2}}{\ttype_2}}$}
       \end{prooftree}
 
       \begin{prooftree}
-        \AxiomC{\Shortstack[c]{{$\pall = \pextend{\pextend{\pextend{\pempty}{\pitem{\evar_1}{\eterm_1}}}{\ldots}}{\pitem{\evar_n}{\eterm_n}}$}
-          {$\tjudgment{\ccontext_1}{\eterm_i}{\twithx{\xunion{\xeffects_{i_1}}{\xeffects_{i_2}}}{\ttype_i}}$}
-          {$\tx_i = \twithx{\xextend{\xeffects_{i_2}}{\xeffect}}{\ttype_i}$}
-          {$\xcitem{\xeffect}{\ccontext_2} \in \xc$}
-          {$\ccontext_2 = \cextend{\cextend{\cextend{\cempty}{\tanno{\evar_1}{\tx_1}}}{\ldots}}{\tanno{\evar_n}{\tx_n}}$}
-          {$\tjudgment{\cunion{\ccontext_1}{\ccontext_2}}{\eterm}{\twithx{\xeffects_2}{\ttype}}$}
-          {$\xeffects_3 = \xunion{\xunion{\xeffects_{1_1}}{\ldots}}{\xeffects_{n_1}}$}}}
-        \RightLabel{(\textsc{T-Provide})}
-        \UnaryInfC{$\tjudgment{\ccontext_1}{\eprovide{\pall}{\xeffect}{\xeffects_1}{\eterm}}{\twithx{\xunion{\xdiff{\xeffects_3}{\xeffects_1}}{\xdiff{\xeffects_2}{\xeffect}}}{\ttype}}$}
+        \AxiomC{\Shortstack[c]{{$\ccontext$,} {$\tanno{\evar}{\twithx{\xextend{\xeffects_1}{\xeffect}}{\ttype}}$,} {$\forall \xeffects_2, \xeffects_3, a \;.\; \tarrow{\twithx{\xunion{\xeffects_1}{\xeffects_3}}{\ttype}}{\tarrow{\twithx{\xextend{\xeffects_2}{\xeffect}}{a}}{\twithx{\xunion{\xeffects_2}{\xeffects_3}}{a}}}$} {$\vdash \tanno{\eterm}{\tx}$}}}
+          \AxiomC{$\xeffect \notin \tx$}
+        \RightLabel{(\textsc{T-Effect})}
+        \BinaryInfC{$\tjudgment{\ccontext}{\eeffect{\xeffect}{\evar}{\twithx{\xeffects_1}{\ttype}}{\eterm}}{\tx}$}
       \end{prooftree}
 
       \caption{Typing rules}\label{fig:typing_rules}
@@ -186,38 +162,38 @@
       \medskip
 
       \begin{prooftree}
-          \AxiomC{$\tjudgment{\cextend{\ccontext}{\tanno{x}{\tx_1}}}{\eterm}{\tx_2}$}
-        \RightLabel{(\textsc{T-Weaken})}
-        \UnaryInfC{$\tjudgment{\ccontext}{\eterm}{\tx_2}$}
+          \AxiomC{$\tjudgment{\ccontext}{\eterm}{\tx_2}$}
+        \RightLabel{(\textsc{$\ccontext$-Weaken})}
+        \UnaryInfC{$\tjudgment{\cextend{\ccontext}{\tanno{x}{\tx_1}}}{\eterm}{\tx_2}$}
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{$\tjudgment{\cunion{\cextend{\cextend{\ccontext_1}{\tanno{x_1}{\tx_1}}}{\tanno{x_2}{\tx_2}}}{\ccontext_2}}{\eterm}{\tx_3}$}
-        \RightLabel{(\textsc{T-Permutation})}
+        \AxiomC{$\tjudgment{\cunion{\cextend{\cextend{\ccontext_1}{\tanno{x_1}{\tx_1}}}{\tanno{x_2}{\tx_2}}}{\ccontext_2}}{\eterm}{\tx_3}$}
+        \RightLabel{(\textsc{$\ccontext$-Permutation})}
         \UnaryInfC{$\tjudgment{\cunion{\cextend{\cextend{\ccontext_1}{\tanno{x_2}{\tx_2}}}{\tanno{x_1}{\tx_1}}}{\ccontext_2}}{\eterm}{\tx_3}$}
       \end{prooftree}
 
       \begin{prooftree}
           \AxiomC{$\tjudgment{\ccontext}{\eterm}{\twithx{\xeffects}{\ttype}}$}
-        \RightLabel{(\textsc{E-Weaken1})}
+        \RightLabel{(\textsc{$\xeffects$-Weaken1})}
         \UnaryInfC{$\tjudgment{\ccontext}{\eterm}{\twithx{\xextend{\xeffects}{\xeffect}}{\ttype}}$}
       \end{prooftree}
 
       \begin{prooftree}
           \AxiomC{$\tjudgment{\cextend{\ccontext}{\tanno{x}{\twithx{\xextend{\xeffects}{\xeffect}}{\ttype}}}}{\eterm}{\tx}$}
-        \RightLabel{(\textsc{E-Weaken2})}
+        \RightLabel{(\textsc{$\xeffects$-Weaken2})}
         \UnaryInfC{$\tjudgment{\cextend{\ccontext}{\tanno{x}{\twithx{\xeffects}{\ttype}}}}{\eterm}{\tx}$}
       \end{prooftree}
 
       \begin{prooftree}
           \AxiomC{$\tjudgment{\ccontext}{\eterm}{\twithx{\xunion{\xextend{\xextend{\xeffects_1}{\xeffect_1}}{\xeffect_2}}{\xeffects_2}}{\ttype}}$}
-        \RightLabel{(\textsc{E-Permutation1})}
+        \RightLabel{(\textsc{$\xeffects$-Permutation1})}
         \UnaryInfC{$\tjudgment{\ccontext}{\eterm}{\twithx{\xunion{\xextend{\xextend{\xeffects_1}{\xeffect_2}}{\xeffect_1}}{\xeffects_2}}{\ttype}}$}
       \end{prooftree}
 
       \begin{prooftree}
           \AxiomC{$\tjudgment{\cextend{\ccontext}{\tanno{x}{\twithx{\xunion{\xextend{\xextend{\xeffects_1}{\xeffect_1}}{\xeffect_2}}{\xeffects_2}}{\ttype}}}}{\eterm}{\tx}$}
-        \RightLabel{(\textsc{E-Permutation2})}
+        \RightLabel{(\textsc{$\xeffects$-Permutation2})}
         \UnaryInfC{$\tjudgment{\cextend{\ccontext}{\tanno{x}{\twithx{\xunion{\xextend{\xextend{\xeffects_1}{\xeffect_2}}{\xeffect_1}}{\xeffects_2}}{\ttype}}}}{\eterm}{\tx}$}
       \end{prooftree}
 


### PR DESCRIPTION
Introduce user-defined effects (single operation for now) and fix some of the weakening rules.

Note: This PR also removes `provide`. What do you think?

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-remove-provide.pdf) is a link to the PDF generated from this PR.
