### PR TITLE
Add a "Draft" watermark to the background

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -8,6 +8,11 @@
 \author{Stephan Boyer and Esther Wang}
 \date{}
 
+% Add a "Draft" watermark to the background
+\usepackage{draftwatermark}
+\SetWatermarkText{\textsc{Draft}}
+\SetWatermarkScale{3}
+
 %%%%%%%%%%%%
 % Packages %
 %%%%%%%%%%%%


### PR DESCRIPTION
Add a "Draft" watermark to the background. If anyone gets a copy of this PDF, they will know it's not the final version.

This seems like the simplest way to add the watermark. I just Googled it and picked the solution with the fewest dependencies.

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-draft-watermark.pdf) is a link to the PDF generated from this PR.
