### PR TITLE
Just use the effect name as the variable rather than putting it in a subscript

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -148,7 +148,7 @@
       \end{prooftree}
 
       \begin{prooftree}
-          \AxiomC{\Shortstack[c]{{$\ccontext$,} {$\tanno{\evar}{\twithx{\xextend{\xeffects_1}{\xeffect}}{\ttype}}$,} {$\tanno{\evar_{\xeffect}}{\forall \xeffects_2, \xeffects_3, a \;.\; \tarrow{\twithx{\xunion{\xeffects_1}{\xeffects_3}}{\ttype}}{\tarrow{\twithx{\xextend{\xeffects_2}{\xeffect}}{a}}{\twithx{\xunion{\xeffects_2}{\xeffects_3}}{a}}}}$} {$\vdash \tanno{\eterm}{\tx}$} {$\xeffect \notin \tx$}}}
+          \AxiomC{\Shortstack[c]{{$\ccontext$,} {$\tanno{\evar}{\twithx{\xextend{\xeffects_1}{\xeffect}}{\ttype}}$,} {$\tanno{\xeffect}{\forall \xeffects_2, \xeffects_3, a \;.\; \tarrow{\twithx{\xunion{\xeffects_1}{\xeffects_3}}{\ttype}}{\tarrow{\twithx{\xextend{\xeffects_2}{\xeffect}}{a}}{\twithx{\xunion{\xeffects_2}{\xeffects_3}}{a}}}}$} {$\vdash \tanno{\eterm}{\tx}$} {$\xeffect \notin \tx$}}}
         \RightLabel{(\textsc{T-Effect})}
         \UnaryInfC{$\tjudgment{\ccontext}{\eeffect{\xeffect}{\evar}{\twithx{\xeffects_1}{\ttype}}{\eterm}}{\tx}$}
       \end{prooftree}


### PR DESCRIPTION
Just use the effect name as the variable rather than putting it in a subscript.

Is this the correct thing to do?

Before:

<img width="101" alt="screenshot 2017-05-21 03 02 08" src="https://cloud.githubusercontent.com/assets/796574/26282959/f995ef6a-3dd1-11e7-8afc-5b3d6f8d7ba1.png">

After:

<img width="93" alt="screenshot 2017-05-21 03 02 30" src="https://cloud.githubusercontent.com/assets/796574/26282961/ffbcf802-3dd1-11e7-8653-d1b4e37912ba.png">

[Here](https://s3.amazonaws.com/stephan-misc/paper/branch-variable-name.pdf) is a link to the PDF generated from this PR.
